### PR TITLE
feat: 3.x JSC 密钥自动提取 / 解密校验 / CCON v2 解码

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ Cocos Creator 逆向工程工具，用于从编译后的 Cocos Creator 游戏中
 - **支持 Spine 骨骼动画资源提取**（骨骼数据 + Atlas 图集 + 纹理）
 - **支持 DragonBones 骨骼动画资源提取**（骨骼数据 + 图集 + 纹理）
 - 生成符合 Cocos Creator 格式要求的项目文件
-- **支持 JSC 加密文件自动解密**（XXTEA + gzip，支持自动提取密钥）
+- **支持 JSC 加密文件自动解密**（XXTEA + gzip，自动提取密钥，覆盖 2.x `main.js` 与 3.x `application.js` / `src/settings.json`；按 magic 校验解密结果，错误密钥不再误报成功）
 - **支持 Cocos Creator 2.3.x / 2.4.x / 3.x 版本自动检测**
 - **3.x bundle 感知**：自动发现 `assets/main`、`assets/internal`、`assets/resources` 及自定义 bundle；按 `config.json` 还原每个资源的原始项目路径
-- **CCON 二进制解码**（`.cconb` / `.ccon` v1）：解析 magic、版本头与对齐 chunk
+- **CCON 二进制解码**（`.cconb` / `.ccon` v1 与 v2）：解析 magic、版本头与对齐 chunk；v2 的 notepack(MessagePack) body 也能解码还原
 - **脚本恢复**：2.x 把打包后的 `project.js` 拆分为每文件 `.ts`；3.x 复制 `src/chunks/*.js`（SystemJS 模块）
 
 ## 版本支持
@@ -46,7 +46,7 @@ Cocos Creator 逆向工程工具，用于从编译后的 Cocos Creator 游戏中
 - 文件结构：`application.js` + `src/settings.json` + `assets/<bundle>/config.json` + `src/chunks/*.js` + `cocos-js/`
 - 按 bundle 独立解析 `config.json`（`paths` + `uuids` + `types` + `versions` + `extensionMap`）
 - 资源按原始项目路径（`assets/main/scenes/Main.scene` 等）还原，并生成匹配的 `.meta`
-- 支持 **CCON v1**（JSON 内嵌 + 8 字节对齐 chunks）；v2（notepack）保留原始数据留给后续处理
+- 支持 **CCON v1**（JSON 内嵌 + 8 字节对齐 chunks）与 **CCON v2**（notepack/MessagePack body 解码为 JSON 文档；无法解码时回退保留 `.ccon-v2.rawjson`）
 - 加密：仅 bundle 级 `index.jsc`，可通过 `--key` 传入或从 `application.js` / `src/settings.json` 自动抽取
 - 使用 `--version-hint 3.x` 强制指定版本；`--bundle <name>` 只处理指定 bundle（可重复）
 

--- a/__tests__/cocos3x/ccon.test.js
+++ b/__tests__/cocos3x/ccon.test.js
@@ -1,7 +1,8 @@
 const { decodeCcon, isCcon, CCON_MAGIC } = require('../../src/core/cocos3x/ccon');
+const { encode: encodeNotepack } = require('./notepack.test');
 
-function buildCcon({ version = 1, json = '{}', chunks = [] }) {
-  const jsonBuf = Buffer.from(json, 'utf-8');
+function buildCcon({ version = 1, json = '{}', body = null, chunks = [] }) {
+  const jsonBuf = body !== null ? body : Buffer.from(json, 'utf-8');
   const jsonLen = jsonBuf.length;
   const headerLen = 16;
   const alignedJsonEnd = ((headerLen + jsonLen) + 7) & ~7;
@@ -65,7 +66,15 @@ describe('decodeCcon', () => {
     expect(decoded.chunks[1].toString('utf-8')).toBe('beta');
   });
 
-  it('returns rawJson for v2 files', () => {
+  it('decodes a v2 file with a notepack body', () => {
+    const doc = { hello: 'world', nums: [1, 2, 3] };
+    const buf = buildCcon({ version: 2, body: encodeNotepack(doc) });
+    const decoded = decodeCcon(buf);
+    expect(decoded.version).toBe(2);
+    expect(decoded.document).toEqual(doc);
+  });
+
+  it('falls back to rawJson when a v2 body is not valid notepack', () => {
     const buf = buildCcon({ version: 2, json: 'notepack-payload' });
     const decoded = decodeCcon(buf);
     expect(decoded.version).toBe(2);

--- a/__tests__/cocos3x/notepack.test.js
+++ b/__tests__/cocos3x/notepack.test.js
@@ -1,0 +1,104 @@
+const { decode } = require('../../src/core/cocos3x/notepack');
+
+/**
+ * Minimal MessagePack encoder for tests — covers the subset the decoder needs
+ * to round-trip: null, bool, ints, float64, str, array, map.
+ */
+function encode(value) {
+  const out = [];
+  enc(value, out);
+  return Buffer.from(out);
+}
+
+function enc(v, out) {
+  if (v === null || v === undefined) { out.push(0xc0); return; }
+  if (v === false) { out.push(0xc2); return; }
+  if (v === true) { out.push(0xc3); return; }
+  if (typeof v === 'number') {
+    if (Number.isInteger(v) && v >= 0 && v <= 0x7f) { out.push(v); return; }
+    if (Number.isInteger(v) && v < 0 && v >= -32) { out.push(v + 0x100); return; }
+    if (Number.isInteger(v) && v >= 0 && v <= 0xffffffff) {
+      out.push(0xce, (v >>> 24) & 0xff, (v >>> 16) & 0xff, (v >>> 8) & 0xff, v & 0xff);
+      return;
+    }
+    // float64
+    const b = Buffer.alloc(8);
+    b.writeDoubleBE(v, 0);
+    out.push(0xcb, ...b);
+    return;
+  }
+  if (typeof v === 'string') {
+    const sb = Buffer.from(v, 'utf-8');
+    if (sb.length <= 31) out.push(0xa0 | sb.length);
+    else { out.push(0xdb, (sb.length >>> 24) & 0xff, (sb.length >>> 16) & 0xff, (sb.length >>> 8) & 0xff, sb.length & 0xff); }
+    out.push(...sb);
+    return;
+  }
+  if (Array.isArray(v)) {
+    if (v.length <= 15) out.push(0x90 | v.length);
+    else out.push(0xdc, (v.length >>> 8) & 0xff, v.length & 0xff);
+    for (const item of v) enc(item, out);
+    return;
+  }
+  if (typeof v === 'object') {
+    const keys = Object.keys(v);
+    if (keys.length <= 15) out.push(0x80 | keys.length);
+    else out.push(0xde, (keys.length >>> 8) & 0xff, keys.length & 0xff);
+    for (const k of keys) { enc(k, out); enc(v[k], out); }
+    return;
+  }
+  throw new Error(`test encoder: unsupported ${typeof v}`);
+}
+
+describe('notepack.decode', () => {
+  it('round-trips primitives', () => {
+    expect(decode(encode(null))).toBeNull();
+    expect(decode(encode(true))).toBe(true);
+    expect(decode(encode(false))).toBe(false);
+    expect(decode(encode(0))).toBe(0);
+    expect(decode(encode(42))).toBe(42);
+    expect(decode(encode(-7))).toBe(-7);
+    expect(decode(encode(70000))).toBe(70000);
+    expect(decode(encode(3.5))).toBeCloseTo(3.5);
+  });
+
+  it('round-trips strings', () => {
+    expect(decode(encode('hello'))).toBe('hello');
+    expect(decode(encode(''))).toBe('');
+    expect(decode(encode('版本'))).toBe('版本');
+    const long = 'x'.repeat(100);
+    expect(decode(encode(long))).toBe(long);
+  });
+
+  it('round-trips arrays and maps', () => {
+    expect(decode(encode([1, 2, 3]))).toEqual([1, 2, 3]);
+    expect(decode(encode({ a: 1, b: 'two' }))).toEqual({ a: 1, b: 'two' });
+  });
+
+  it('round-trips a nested IFileData-like tuple', () => {
+    const doc = [
+      [[{ __type__: 'cc.SpriteFrame', _name: 'icon' }]],
+      [0],
+      [],
+      [],
+      [],
+      [],
+    ];
+    expect(decode(encode(doc))).toEqual(doc);
+  });
+
+  it('rejects buffers with trailing bytes', () => {
+    const buf = Buffer.concat([encode(1), Buffer.from([0xff])]);
+    expect(() => decode(buf)).toThrow(/trailing/);
+  });
+
+  it('throws on empty buffer', () => {
+    expect(() => decode(Buffer.alloc(0))).toThrow();
+  });
+
+  it('throws on unknown prefix', () => {
+    expect(() => decode(Buffer.from([0xc1]))).toThrow(/unknown prefix/);
+  });
+});
+
+module.exports = { encode };

--- a/__tests__/jscDecryptor.test.js
+++ b/__tests__/jscDecryptor.test.js
@@ -63,6 +63,43 @@ describe('jscDecryptor', () => {
       const key = extractKeyFromProject(tmpDir);
       expect(key).toBeNull();
     });
+
+    test('should extract key from 3.x application.js', () => {
+      fs.writeFileSync(path.join(tmpDir, 'application.js'), `
+        System.register(function () {
+          var xxteaKey = "app-level-key-987654";
+        });
+      `);
+      const key = extractKeyFromProject(tmpDir);
+      expect(key).toBe('app-level-key-987654');
+    });
+
+    test('should extract key from 3.x src/settings.json', () => {
+      fs.mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, 'src', 'settings.json'),
+        JSON.stringify({ assets: {}, xxteaKey: 'settings-json-key-555' })
+      );
+      const key = extractKeyFromProject(tmpDir);
+      expect(key).toBe('settings-json-key-555');
+    });
+
+    test('should extract key from hashed src/settings.<hash>.json', () => {
+      fs.mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, 'src', 'settings.abc123.json'),
+        JSON.stringify({ encryptKey: 'hashed-settings-key-444' })
+      );
+      const key = extractKeyFromProject(tmpDir);
+      expect(key).toBe('hashed-settings-key-444');
+    });
+
+    test('should extract key from setXXTEAKey call', () => {
+      fs.writeFileSync(path.join(tmpDir, 'main.js'),
+        `cc.sys.localStorage; jsb.fileUtils.setXXTEAKey('call-style-key-321');`);
+      const key = extractKeyFromProject(tmpDir);
+      expect(key).toBe('call-style-key-321');
+    });
   });
 
   describe('decryptJscBuffer', () => {
@@ -92,6 +129,22 @@ describe('jscDecryptor', () => {
       const encrypted = xxtea.encrypt(original, xxtea.toBytes(TEST_KEY));
       const result = decryptJscBuffer(encrypted, 'wrong-key-12345678');
       expect(result).toBeNull();
+    });
+
+    test('should reject garbage output that is not valid JS text', () => {
+      // Encrypt high-entropy binary, then decrypt with a different key so the
+      // output is non-text noise; it must be rejected rather than reported ok.
+      const binary = Buffer.from(Array.from({ length: 64 }, (_, i) => (i * 37) & 0xff));
+      const encrypted = xxtea.encrypt(binary, xxtea.toBytes(TEST_KEY));
+      const result = decryptJscBuffer(encrypted, 'another-wrong-key-99');
+      expect(result).toBeNull();
+    });
+
+    test('should accept correctly decrypted minified JS', () => {
+      const original = Buffer.from('!function(){var a=1,b=2;return a+b}();');
+      const encrypted = xxtea.encrypt(original, xxtea.toBytes(TEST_KEY));
+      const result = decryptJscBuffer(encrypted, TEST_KEY);
+      expect(result.toString('utf-8')).toBe('!function(){var a=1,b=2;return a+b}();');
     });
   });
 });

--- a/src/core/cocos3x/ccon.js
+++ b/src/core/cocos3x/ccon.js
@@ -15,21 +15,23 @@
  *     u8[chunkLen] data
  */
 
+const { decode: notepackDecode } = require('./notepack');
+
 const CCON_MAGIC = 0x4E4F4343;
 
 /**
  * Decode a CCON buffer.
  *
- * Version 1 files are returned fully decoded: `.document` is the parsed JSON
- * (an IFileData tuple).
+ * Version 1 files carry a JSON body; version 2 files carry a notepack
+ * (MessagePack) body. Both are returned fully decoded: `.document` is the
+ * parsed IFileData tuple.
  *
- * Version 2 files use a notepack body; we do not ship a notepack decoder yet,
- * so we return `{ version: 2, rawJson: <Buffer>, chunks: [...] }` and let the
- * caller decide whether to fail, or to hand the raw json buffer to an external
- * decoder.
+ * If a v2 body cannot be decoded (corrupt / unexpected format) we fall back to
+ * `{ version: 2, rawJson: <Buffer>, chunks: [...] }` so the caller can still
+ * persist the raw blob instead of losing it.
  *
  * @param {Buffer} buf
- * @returns {{ version: number, document: any, chunks: Buffer[], rawJson?: Buffer }}
+ * @returns {{ version: number, document?: any, chunks: Buffer[], rawJson?: Buffer }}
  */
 function decodeCcon(buf) {
   if (!Buffer.isBuffer(buf)) {
@@ -65,9 +67,18 @@ function decodeCcon(buf) {
   const rawJson = buf.slice(jsonStart, jsonEnd);
 
   let document = null;
+  let decodeError = null;
   if (version === 1) {
     const text = rawJson.toString('utf-8');
     document = JSON.parse(text);
+  } else if (version === 2) {
+    // v2 body is a notepack (MessagePack) blob.
+    try {
+      document = notepackDecode(rawJson);
+    } catch (e) {
+      decodeError = e;
+      document = null;
+    }
   }
 
   // Chunks follow, aligned to 8 bytes after the JSON blob.
@@ -96,7 +107,9 @@ function decodeCcon(buf) {
   if (document !== null) {
     result.document = document;
   } else {
+    // Couldn't decode (e.g. malformed v2 body) — keep the raw blob.
     result.rawJson = rawJson;
+    if (decodeError) result.decodeError = decodeError;
   }
   return result;
 }

--- a/src/core/cocos3x/engine3x.js
+++ b/src/core/cocos3x/engine3x.js
@@ -611,15 +611,17 @@ function probeNativeExtension(doc) {
 
 async function decodeCconToDoc(buf, outBase) {
   const decoded = decodeCcon(buf);
-  if (decoded.version === 1 && decoded.document) {
+  // Both v1 (JSON) and v2 (notepack) yield a `document` when decodable.
+  if (decoded.document) {
     // Persist chunks alongside the JSON so mesh/animation payloads are not lost.
     for (let i = 0; i < decoded.chunks.length; i += 1) {
       await writeFile(`${outBase}.chunk${i}.bin`, decoded.chunks[i]);
     }
     return decoded.document;
   }
-  // V2 (notepack) — preserve raw blobs; we can't currently decode.
+  // Undecodable v2 body — preserve the raw blob so nothing is silently lost.
   if (decoded.rawJson) {
+    logger.warn(`CCON v2 body could not be decoded, kept raw: ${path.basename(outBase)}.ccon-v2.rawjson`);
     await writeFile(outBase + '.ccon-v2.rawjson', decoded.rawJson);
   }
   for (let i = 0; i < decoded.chunks.length; i += 1) {

--- a/src/core/cocos3x/notepack.js
+++ b/src/core/cocos3x/notepack.js
@@ -1,0 +1,207 @@
+/*
+ * Minimal MessagePack decoder.
+ *
+ * Cocos Creator 3.x CCON version-2 files encode their JSON body with
+ * "notepack" (https://github.com/darrachequesne/notepack), a MessagePack
+ * implementation. This is a dependency-free decoder covering the MessagePack
+ * wire format that notepack emits, so we can turn a v2 body back into the same
+ * IFileData tuple a v1 body would have carried.
+ *
+ * Spec: https://github.com/msgpack/msgpack/blob/master/spec.md
+ */
+
+class Decoder {
+  constructor(buf) {
+    this.buf = buf;
+    this.offset = 0;
+  }
+
+  parse() {
+    if (this.offset >= this.buf.length) {
+      throw new RangeError('notepack: unexpected end of buffer');
+    }
+    const prefix = this.buf[this.offset];
+    this.offset += 1;
+
+    // positive fixint
+    if (prefix < 0x80) return prefix;
+    // negative fixint
+    if (prefix >= 0xe0) return prefix - 0x100;
+    // fixstr
+    if (prefix >= 0xa0 && prefix <= 0xbf) return this.readStr(prefix & 0x1f);
+    // fixmap
+    if (prefix >= 0x80 && prefix <= 0x8f) return this.readMap(prefix & 0x0f);
+    // fixarray
+    if (prefix >= 0x90 && prefix <= 0x9f) return this.readArray(prefix & 0x0f);
+
+    switch (prefix) {
+      case 0xc0: return null;
+      case 0xc2: return false;
+      case 0xc3: return true;
+
+      case 0xc4: return this.readBin(this.readUInt(1));
+      case 0xc5: return this.readBin(this.readUInt(2));
+      case 0xc6: return this.readBin(this.readUInt(4));
+
+      case 0xc7: return this.readExt(this.readUInt(1));
+      case 0xc8: return this.readExt(this.readUInt(2));
+      case 0xc9: return this.readExt(this.readUInt(4));
+
+      case 0xca: return this.readFloat(4);
+      case 0xcb: return this.readFloat(8);
+
+      case 0xcc: return this.readUInt(1);
+      case 0xcd: return this.readUInt(2);
+      case 0xce: return this.readUInt(4);
+      case 0xcf: return this.readUInt64();
+
+      case 0xd0: return this.readInt(1);
+      case 0xd1: return this.readInt(2);
+      case 0xd2: return this.readInt(4);
+      case 0xd3: return this.readInt64();
+
+      case 0xd4: return this.readExtFixed(1);
+      case 0xd5: return this.readExtFixed(2);
+      case 0xd6: return this.readExtFixed(4);
+      case 0xd7: return this.readExtFixed(8);
+      case 0xd8: return this.readExtFixed(16);
+
+      case 0xd9: return this.readStr(this.readUInt(1));
+      case 0xda: return this.readStr(this.readUInt(2));
+      case 0xdb: return this.readStr(this.readUInt(4));
+
+      case 0xdc: return this.readArray(this.readUInt(2));
+      case 0xdd: return this.readArray(this.readUInt(4));
+
+      case 0xde: return this.readMap(this.readUInt(2));
+      case 0xdf: return this.readMap(this.readUInt(4));
+
+      default:
+        throw new Error(`notepack: unknown prefix 0x${prefix.toString(16)} at ${this.offset - 1}`);
+    }
+  }
+
+  require(n) {
+    if (this.offset + n > this.buf.length) {
+      throw new RangeError('notepack: unexpected end of buffer');
+    }
+  }
+
+  readUInt(size) {
+    this.require(size);
+    let v;
+    switch (size) {
+      case 1: v = this.buf.readUInt8(this.offset); break;
+      case 2: v = this.buf.readUInt16BE(this.offset); break;
+      case 4: v = this.buf.readUInt32BE(this.offset); break;
+      default: throw new Error(`notepack: bad uint size ${size}`);
+    }
+    this.offset += size;
+    return v;
+  }
+
+  readInt(size) {
+    this.require(size);
+    let v;
+    switch (size) {
+      case 1: v = this.buf.readInt8(this.offset); break;
+      case 2: v = this.buf.readInt16BE(this.offset); break;
+      case 4: v = this.buf.readInt32BE(this.offset); break;
+      default: throw new Error(`notepack: bad int size ${size}`);
+    }
+    this.offset += size;
+    return v;
+  }
+
+  readUInt64() {
+    this.require(8);
+    const v = this.buf.readBigUInt64BE(this.offset);
+    this.offset += 8;
+    return v <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(v) : v;
+  }
+
+  readInt64() {
+    this.require(8);
+    const v = this.buf.readBigInt64BE(this.offset);
+    this.offset += 8;
+    const min = BigInt(Number.MIN_SAFE_INTEGER);
+    const max = BigInt(Number.MAX_SAFE_INTEGER);
+    return v >= min && v <= max ? Number(v) : v;
+  }
+
+  readFloat(size) {
+    this.require(size);
+    const v = size === 4
+      ? this.buf.readFloatBE(this.offset)
+      : this.buf.readDoubleBE(this.offset);
+    this.offset += size;
+    return v;
+  }
+
+  readStr(len) {
+    this.require(len);
+    const s = this.buf.toString('utf-8', this.offset, this.offset + len);
+    this.offset += len;
+    return s;
+  }
+
+  readBin(len) {
+    this.require(len);
+    const b = this.buf.slice(this.offset, this.offset + len);
+    this.offset += len;
+    return b;
+  }
+
+  readArray(len) {
+    const arr = new Array(len);
+    for (let i = 0; i < len; i += 1) arr[i] = this.parse();
+    return arr;
+  }
+
+  readMap(len) {
+    const obj = {};
+    for (let i = 0; i < len; i += 1) {
+      const key = this.parse();
+      obj[String(key)] = this.parse();
+    }
+    return obj;
+  }
+
+  readExt(len) {
+    // type byte, then `len` bytes of data — preserved as raw bytes.
+    this.require(len + 1);
+    const type = this.buf.readInt8(this.offset);
+    const data = this.buf.slice(this.offset + 1, this.offset + 1 + len);
+    this.offset += len + 1;
+    return { __ext__: type, data };
+  }
+
+  readExtFixed(len) {
+    return this.readExt(len);
+  }
+}
+
+/**
+ * Decode a MessagePack (notepack) buffer into a JS value.
+ * @param {Buffer} buf
+ * @returns {any}
+ */
+function decode(buf) {
+  if (!Buffer.isBuffer(buf)) {
+    throw new TypeError('notepack.decode: expected Buffer');
+  }
+  if (buf.length === 0) {
+    throw new RangeError('notepack.decode: empty buffer');
+  }
+  const dec = new Decoder(buf);
+  const value = dec.parse();
+  // A well-formed body encodes exactly one value and consumes the whole
+  // buffer. Trailing bytes mean this isn't notepack (or it's corrupt), so we
+  // reject rather than silently returning a partial decode.
+  if (dec.offset !== buf.length) {
+    throw new Error(`notepack.decode: ${buf.length - dec.offset} trailing byte(s)`);
+  }
+  return value;
+}
+
+module.exports = { decode };

--- a/src/core/jscDecryptor.js
+++ b/src/core/jscDecryptor.js
@@ -33,29 +33,62 @@ function scanJscFiles(dirPath) {
   return results;
 }
 
+// 可能内联 XXTEA 密钥的项目文件，按命中优先级排列。
+// 2.x 密钥通常在 main.js；3.x 在 application.js 或 src/settings.json。
+const KEY_FILE_CANDIDATES = [
+  'main.js',
+  'src/main.js',
+  'application.js',
+  'src/application.js',
+  'src/settings.json',
+  'src/project.js',
+  'project.js',
+  'index.js',
+  'game.js',
+];
+
+// 同时适配 `var k = '...'`、`k: '...'`、JSON `"k":"..."` 以及 setXXTEAKey('...')。
+const KEY_PATTERNS = [
+  /setXXTEAKey\s*\(\s*['"]([^'"]+)['"]\s*\)/,
+  /xxteaKey['"]?\s*[:=]\s*['"]([^'"]+)['"]/i,
+  /encrypt(?:ion)?Key['"]?\s*[:=]\s*['"]([^'"]+)['"]/i,
+  /XXTEA_KEY['"]?\s*[:=]\s*['"]([^'"]+)['"]/i,
+  /key\s*:\s*['"]([0-9a-f-]{16,})['"]/i,
+  /['"]([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{2})['"]/i,
+];
+
 /**
- * 从项目文件中自动提取 XXTEA 密钥
+ * 从项目文件中自动提取 XXTEA 密钥。
+ * 覆盖 2.x（main.js）与 3.x（application.js / src/settings.json）布局。
  * @param {string} sourcePath 源项目路径
  * @returns {string|null} 密钥或 null
  */
 function extractKeyFromProject(sourcePath) {
-  const candidates = ['main.js', 'src/main.js'];
+  // src/settings.*.json 这类带 hash 的 3.x 配置也纳入扫描。
+  const candidates = [...KEY_FILE_CANDIDATES];
+  const srcDir = path.join(sourcePath, 'src');
+  if (fs.existsSync(srcDir)) {
+    try {
+      for (const f of fs.readdirSync(srcDir)) {
+        if (/^settings\..+\.json$/.test(f)) candidates.push(path.join('src', f));
+      }
+    } catch (e) {
+      // 目录不可读则忽略
+    }
+  }
 
   for (const candidate of candidates) {
     const filePath = path.join(sourcePath, candidate);
     if (!fs.existsSync(filePath)) continue;
 
-    const content = fs.readFileSync(filePath, 'utf-8');
+    let content;
+    try {
+      content = fs.readFileSync(filePath, 'utf-8');
+    } catch (e) {
+      continue;
+    }
 
-    const patterns = [
-      /xxteaKey\s*=\s*['"]([^'"]+)['"]/,
-      /encryptKey\s*=\s*['"]([^'"]+)['"]/,
-      /XXTEA_KEY\s*=\s*['"]([^'"]+)['"]/,
-      /key\s*:\s*['"]([0-9a-f-]{16,})['"]/i,
-      /['"]([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{2})['"]/i,
-    ];
-
-    for (const pattern of patterns) {
+    for (const pattern of KEY_PATTERNS) {
       const match = content.match(pattern);
       if (match) {
         return match[1];
@@ -67,20 +100,52 @@ function extractKeyFromProject(sourcePath) {
 }
 
 /**
- * 解密单个 JSC 文件数据
+ * 启发式判断缓冲区是否为文本（JavaScript 源码）。
+ * 正确解密的 .jsc 是 JS 源码；错误密钥产出的是高熵二进制乱码。
+ * @param {Buffer} buf
+ * @returns {boolean}
+ */
+function looksLikeText(buf) {
+  const n = Math.min(buf.length, 512);
+  if (n === 0) return false;
+  let printable = 0;
+  for (let i = 0; i < n; i += 1) {
+    const b = buf[i];
+    // 制表/换行/回车 或 可打印 ASCII 视为文本字符。
+    if (b === 9 || b === 10 || b === 13 || (b >= 32 && b < 127)) printable += 1;
+  }
+  return printable / n >= 0.85;
+}
+
+/**
+ * 解密单个 JSC 文件数据。
+ * 返回 null 表示解密失败（密钥错误或数据损坏），调用方据此计入失败而非误报成功。
  * @param {Buffer} data 文件数据
  * @param {string} key 解密密钥
  * @returns {Buffer|null} 解密后的数据或 null
  */
 function decryptJscBuffer(data, key) {
   const decrypted = xxtea.decrypt(data, xxtea.toBytes(key));
-  if (!decrypted) return null;
+  if (!decrypted || decrypted.length === 0) return null;
 
-  try {
-    return Buffer.from(pako.inflate(decrypted));
-  } catch (e) {
-    return Buffer.from(decrypted);
+  const buf = Buffer.from(decrypted);
+
+  // 按 magic 判断压缩格式：gzip(1f 8b) 或 zlib(78 ..)。
+  const isGzip = buf.length >= 2 && buf[0] === 0x1f && buf[1] === 0x8b;
+  const isZlib = buf.length >= 2 && buf[0] === 0x78
+    && (buf[1] === 0x01 || buf[1] === 0x9c || buf[1] === 0xda);
+  if (isGzip || isZlib) {
+    try {
+      return Buffer.from(pako.inflate(buf));
+    } catch (e) {
+      // magic 声称已压缩却解压失败 → 密钥错误或数据损坏。
+      return null;
+    }
   }
+
+  // 未压缩：正确解密的 .jsc 应为 JS 源码文本，乱码则判为失败。
+  if (looksLikeText(buf)) return buf;
+  return null;
 }
 
 /**

--- a/src/core/reverseEngine.js
+++ b/src/core/reverseEngine.js
@@ -58,7 +58,7 @@ async function reverseProject(options) {
       bundleFilter: Array.isArray(bundle) ? bundle : (bundle ? [bundle] : []),
       assetsOnly,
       scriptsOnly,
-      key: key || global.config.decrypt?.key,
+      key: key || global.config.decrypt?.key || extractKeyFromProject(sourcePath),
       verbose,
     });
   }


### PR DESCRIPTION
## 改进现有功能(P0)

### 1. JSC 密钥自动提取增强(支持 3.x)
- `extractKeyFromProject` 扫描范围从 `main.js`/`src/main.js` 扩展到 `application.js`、`src/settings.json`、带 hash 的 `settings.*.json`、`project.js`、`index.js`、`game.js`
- 正则新增 `setXXTEAKey('...')` 调用式与 JSON `"key":"..."` 式
- 在 `reverseEngine.js` 的 3.x 分支接入自动提取 —— 之前 3.x 只能手动 `--key`,README 宣称的"自动抽取"对 3.x 实际不生效

### 2. JSC 解密结果校验
- 改用 magic bytes(gzip `1f 8b` / zlib `78`)判断压缩,而非 try/catch
- 声称压缩却解压失败、或未压缩但输出非 JS 文本(高熵乱码)→ 返回 `null` 计入失败
- **错误密钥不再被当成"解密成功"写盘**,避免用户拿到损坏文件还以为成功

### 3. CCON v2 (notepack) 解码
- 新增零依赖的 MessagePack(notepack)解码器 `cocos3x/notepack.js`
- `ccon.js` 对 v2 body 解码为 `document`,与 v1 同等处理;无法解码时回退保留 `.ccon-v2.rawjson`
- `engine3x.js` 不再对 v2 直接丢弃 —— 之前 3.4+ 的 CCON v2 资源会 `output=null` 丢失

## 测试
- `jest`:**10 套件 / 94 用例全绿**
- 新增:notepack 往返、CCON v2 解码 + 回退、3.x 密钥提取、解密乱码拒绝等用例

🤖 Generated with [Claude Code](https://claude.com/claude-code)