### PR TITLE
fix: decode Fire Kirin obfuscated native assets

### DIFF
--- a/__tests__/assetDeobfuscator.roundtrip.test.js
+++ b/__tests__/assetDeobfuscator.roundtrip.test.js
@@ -1,0 +1,189 @@
+/**
+ * Round-trip decodability tests for assetDeobfuscator, covering the full
+ * 2x2 matrix of (scheme x loader path):
+ *
+ *   | Scheme  | Loader path  | Expected transform          |
+ *   |---------|--------------|------------------------------|
+ *   | 11-byte | image/blob   | strip 11                    |
+ *   | 11-byte | arraybuffer  | strip 11 + XOR 1             |
+ *   | 18-byte | image/blob   | strip 18 + 74               |
+ *   | 18-byte | arraybuffer  | strip 18 + rotating-key XOR  |
+ *
+ * __tests__/assetDeobfuscator.test.js already covers the transforms with
+ * synthetic buffers (prefix arithmetic only). This file additionally proves
+ * each branch produces a *decodable* artifact: for the image rows, a real
+ * minimal valid PNG is built in-code, obfuscated, deobfuscated, and the
+ * result is asserted byte-exact against the original PNG AND independently
+ * decodable via `image-size` (a real PNG parser, not just a byte compare).
+ * For the arraybuffer rows, a synthetic binary payload proves the XOR is
+ * correctly inverted (XOR is its own inverse).
+ *
+ * No real game assets are used as fixtures; everything is constructed here.
+ */
+
+const zlib = require('zlib');
+const sizeOf = require('image-size');
+const {
+  deobfuscateAsset,
+  MARKER_A,
+  MARKER_B,
+  MARKER_B_IMAGE_PAD,
+  XOR_KEY,
+} = require('../src/core/assetDeobfuscator');
+
+// ---------------------------------------------------------------------------
+// Minimal real PNG builder (no external deps; hand-rolled CRC32 + Node's
+// built-in zlib for the IDAT deflate stream).
+// ---------------------------------------------------------------------------
+
+const CRC_TABLE = (() => {
+  const table = new Array(256);
+  for (let n = 0; n < 256; n += 1) {
+    let c = n;
+    for (let k = 0; k < 8; k += 1) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[n] = c;
+  }
+  return table;
+})();
+
+/** @param {Buffer} buf @returns {number} */
+function crc32(buf) {
+  let crc = 0xffffffff;
+  for (let i = 0; i < buf.length; i += 1) {
+    crc = CRC_TABLE[(crc ^ buf[i]) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+/** @param {string} tag 4-char chunk type @param {Buffer} data @returns {Buffer} */
+function pngChunk(tag, data) {
+  const len = Buffer.alloc(4);
+  len.writeUInt32BE(data.length, 0);
+  const tagAndData = Buffer.concat([Buffer.from(tag, 'latin1'), data]);
+  const crc = Buffer.alloc(4);
+  crc.writeUInt32BE(crc32(tagAndData), 0);
+  return Buffer.concat([len, tagAndData, crc]);
+}
+
+/**
+ * Build a real, valid, minimal 2x2 RGB PNG (8-bit, no filter tricks beyond
+ * "none") entirely in-code. Independently decodable by any PNG parser.
+ * @returns {Buffer}
+ */
+function buildMinimalPng() {
+  const SIG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const width = 2;
+  const height = 2;
+  const ihdr = Buffer.alloc(13);
+  ihdr.writeUInt32BE(width, 0);
+  ihdr.writeUInt32BE(height, 4);
+  ihdr.writeUInt8(8, 8); // bit depth
+  ihdr.writeUInt8(2, 9); // color type: RGB
+  ihdr.writeUInt8(0, 10); // compression
+  ihdr.writeUInt8(0, 11); // filter method
+  ihdr.writeUInt8(0, 12); // interlace
+
+  // 2 scanlines, each: 1 filter-type byte (0 = none) + 2 RGB pixels (6 bytes).
+  const raw = Buffer.from([
+    0, 255, 0, 0, 0, 255, 0, // row 0: red, green
+    0, 0, 0, 255, 128, 128, 128, // row 1: blue, gray
+  ]);
+  const idat = zlib.deflateSync(raw);
+
+  return Buffer.concat([SIG, pngChunk('IHDR', ihdr), pngChunk('IDAT', idat), pngChunk('IEND', Buffer.alloc(0))]);
+}
+
+/** @param {Buffer[]} keyBytes @param {Buffer} data @returns {Buffer} */
+function rotatingXor(data, key) {
+  const out = Buffer.alloc(data.length);
+  let c = 0;
+  for (let i = 0; i < data.length; i += 1) {
+    if (c >= key.length) c = 0;
+    out[i] = data[i] ^ key[c];
+    c += 1;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures shared across tests
+// ---------------------------------------------------------------------------
+
+const REAL_PNG = buildMinimalPng();
+const REAL_PNG_DIMS = sizeOf(REAL_PNG);
+
+describe('assetDeobfuscator round-trip decodability (2x2 scheme x loader-path matrix)', () => {
+  beforeAll(() => {
+    // Sanity: the fixture itself must be a real, decodable PNG before we
+    // start obfuscating/deobfuscating it, otherwise every test below is
+    // meaningless.
+    expect(REAL_PNG_DIMS).toEqual({ width: 2, height: 2, type: 'png' });
+  });
+
+  it('11-byte marker (ADW), image/blob path: strip 11, byte-exact PNG, still decodable', () => {
+    const obfuscated = Buffer.concat([MARKER_A, REAL_PNG]);
+
+    const { data, scheme } = deobfuscateAsset(obfuscated, '.png');
+
+    expect(scheme).toBe('ADW');
+    expect(data).toEqual(REAL_PNG);
+    expect(sizeOf(data)).toEqual(REAL_PNG_DIMS);
+  });
+
+  it('11-byte marker (ADW), arraybuffer path: strip 11 + XOR 1, round-trips a binary payload', () => {
+    const plaintext = Buffer.from('BINARY-PAYLOAD-not-a-real-mp3-just-bytes-0123456789', 'latin1');
+    const xored = Buffer.from(plaintext.map((b) => b ^ 1));
+    const obfuscated = Buffer.concat([MARKER_A, xored]);
+
+    const { data, scheme } = deobfuscateAsset(obfuscated, '.mp3');
+
+    expect(scheme).toBe('ADW');
+    expect(data).toEqual(plaintext);
+    // XOR is its own inverse: re-applying XOR 1 to the recovered plaintext
+    // must reproduce exactly the bytes that were on the wire.
+    expect(Buffer.from(data.map((b) => b ^ 1))).toEqual(xored);
+  });
+
+  it('18-byte marker (Gj) + 74-byte pad, image/blob path: strip 92, byte-exact PNG, still decodable', () => {
+    const pad = Buffer.alloc(MARKER_B_IMAGE_PAD, 0x00);
+    expect(MARKER_B.length + MARKER_B_IMAGE_PAD).toBe(92);
+    const obfuscated = Buffer.concat([MARKER_B, pad, REAL_PNG]);
+
+    const { data, scheme } = deobfuscateAsset(obfuscated, '.png');
+
+    expect(scheme).toBe('Gj');
+    expect(data).toEqual(REAL_PNG);
+    expect(sizeOf(data)).toEqual(REAL_PNG_DIMS);
+  });
+
+  it('18-byte marker (Gj), arraybuffer path: strip 18 + rotating-key XOR, round-trips a binary payload', () => {
+    // Longer than the 16-byte key so the rotation must wrap at least once.
+    const plaintext = Buffer.from('BINARY-PAYLOAD-longer-than-the-sixteen-byte-rotating-key-0123456789', 'latin1');
+    expect(plaintext.length).toBeGreaterThan(XOR_KEY.length);
+    const xored = rotatingXor(plaintext, XOR_KEY);
+    const obfuscated = Buffer.concat([MARKER_B, xored]);
+
+    const { data, scheme } = deobfuscateAsset(obfuscated, '.mp3');
+
+    expect(scheme).toBe('Gj');
+    expect(data).toEqual(plaintext);
+    // XOR is its own inverse: re-applying the rotating key to the recovered
+    // plaintext must reproduce exactly the bytes that were on the wire.
+    expect(rotatingXor(data, XOR_KEY)).toEqual(xored);
+  });
+
+  it('jpeg through the Gj+74 image branch also round-trips byte-exact', () => {
+    // Confidence check that .jpeg (not just .png) is routed through the
+    // same header-strip-only image branch and comes out byte-exact.
+    const fakeJpeg = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01]);
+    const pad = Buffer.alloc(MARKER_B_IMAGE_PAD, 0x00);
+    const obfuscated = Buffer.concat([MARKER_B, pad, fakeJpeg]);
+
+    const { data, scheme } = deobfuscateAsset(obfuscated, '.jpeg');
+
+    expect(scheme).toBe('Gj');
+    expect(data).toEqual(fakeJpeg);
+  });
+});

--- a/__tests__/assetDeobfuscator.test.js
+++ b/__tests__/assetDeobfuscator.test.js
@@ -1,0 +1,93 @@
+const {
+  deobfuscateAsset,
+  MARKER_A,
+  MARKER_B,
+  MARKER_B_IMAGE_PAD,
+  XOR_KEY,
+} = require('../src/core/assetDeobfuscator');
+
+/** Build a fake PNG-ish plaintext payload of the given length. */
+function makePlaintext(length, fill = 0x41) {
+  return Buffer.alloc(length, fill);
+}
+
+describe('deobfuscateAsset', () => {
+  it('MARKER_A image: strips the 11-byte header, applies no XOR', () => {
+    const plaintext = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x01, 0x02, 0x03]);
+    const obfuscated = Buffer.concat([MARKER_A, plaintext]);
+
+    const { data, scheme } = deobfuscateAsset(obfuscated, '.png');
+
+    expect(scheme).toBe('ADW');
+    expect(data).toEqual(plaintext);
+  });
+
+  it('MARKER_B image: strips 18 + 74 = 92 bytes, applies no XOR', () => {
+    const plaintext = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46]);
+    const padding = makePlaintext(MARKER_B_IMAGE_PAD, 0x00);
+    const obfuscated = Buffer.concat([MARKER_B, padding, plaintext]);
+
+    expect(MARKER_B.length + MARKER_B_IMAGE_PAD).toBe(92);
+
+    const { data, scheme } = deobfuscateAsset(obfuscated, '.jpg');
+
+    expect(scheme).toBe('Gj');
+    expect(data).toEqual(plaintext);
+  });
+
+  it('MARKER_A binary: strips the 11-byte header, then XORs every byte with 1', () => {
+    const plaintext = Buffer.from('ID3plaintextpayload', 'latin1');
+    const xored = Buffer.from(plaintext.map((b) => b ^ 1));
+    const obfuscated = Buffer.concat([MARKER_A, xored]);
+
+    const { data, scheme } = deobfuscateAsset(obfuscated, '.mp3');
+
+    expect(scheme).toBe('ADW');
+    expect(data).toEqual(plaintext);
+  });
+
+  it('MARKER_B binary: strips the 18-byte header, then applies rotating-key XOR that wraps past 16 bytes', () => {
+    // 20 bytes of plaintext — longer than the 16-byte key, so the key must wrap.
+    const plaintext = Buffer.from('ID3-payload-longer!!', 'latin1');
+    expect(plaintext.length).toBeGreaterThan(XOR_KEY.length);
+
+    const xored = Buffer.alloc(plaintext.length);
+    let c = 0;
+    for (let i = 0; i < plaintext.length; i += 1) {
+      if (c >= XOR_KEY.length) c = 0;
+      xored[i] = plaintext[i] ^ XOR_KEY[c];
+      c += 1;
+    }
+    const obfuscated = Buffer.concat([MARKER_B, xored]);
+
+    const { data, scheme } = deobfuscateAsset(obfuscated, '.mp3');
+
+    expect(scheme).toBe('Gj');
+    expect(data).toEqual(plaintext);
+    // Sanity: verify the key actually wrapped for this fixture (length > 16).
+    expect(plaintext.length).toBeGreaterThan(16);
+  });
+
+  it('plain input (no marker) is returned byte-identical for both branches', () => {
+    const plainImage = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const plainBinary = Buffer.from('ID3 no marker here', 'latin1');
+
+    const imageResult = deobfuscateAsset(plainImage, '.png');
+    const binaryResult = deobfuscateAsset(plainBinary, '.mp3');
+
+    expect(imageResult.scheme).toBe('plain');
+    expect(imageResult.data).toEqual(plainImage);
+    expect(binaryResult.scheme).toBe('plain');
+    expect(binaryResult.data).toEqual(plainBinary);
+  });
+
+  it('routes .jpeg to the image branch too', () => {
+    const plaintext = Buffer.from([0xff, 0xd8, 0xff, 0xe0]);
+    const obfuscated = Buffer.concat([MARKER_A, plaintext]);
+
+    const { data, scheme } = deobfuscateAsset(obfuscated, '.jpeg');
+
+    expect(scheme).toBe('ADW');
+    expect(data).toEqual(plaintext);
+  });
+});

--- a/src/core/assetDeobfuscator.js
+++ b/src/core/assetDeobfuscator.js
@@ -1,0 +1,113 @@
+/*
+ * De-obfuscation for native binary assets served by games that obfuscate
+ * their asset bundles (e.g. Fire Kirin's CommLoading downloader).
+ *
+ * The server prepends a marker header to certain files. The loader strips
+ * that header client-side, and for the arraybuffer branch also XORs the
+ * payload. cc-reverse copies bytes verbatim, so recovered images/audio are
+ * left obfuscated unless this module is applied on write.
+ *
+ * Algorithm reverse-engineered from the game's own loader at
+ * `CommLoading/downLoadPlugin.fd4e9.js`. Two independent marker schemes,
+ * and two independent branches (image vs. binary) with different handling:
+ *
+ *   - Image branch (responseType === 'blob', used for png/jpg/jpeg):
+ *       strip header only, no XOR.
+ *   - Binary branch (responseType === 'arraybuffer', used for audio and
+ *     other binaries): strip header AND XOR the remaining bytes.
+ */
+
+/** MARKER_A header, 11 bytes. */
+const MARKER_A = Buffer.from('@@@ADW@@@%%', 'latin1');
+
+/** MARKER_B header, 18 bytes (contains a backtick). */
+const MARKER_B = Buffer.from("Gj&e5/S%*z]~)i!O`r", 'latin1');
+
+/** Extra bytes stripped after MARKER_B in the image branch only. */
+const MARKER_B_IMAGE_PAD = 74;
+
+/** Rotating XOR key used for MARKER_B in the binary branch. */
+const XOR_KEY = [75, 108, 38, 101, 5, 47, 82, 35, 41, 93, 126, 43, 105, 79, 96, 118];
+
+/** Extensions routed through the image branch (blob, header-strip only). */
+const IMAGE_EXTS = new Set(['.png', '.jpg', '.jpeg']);
+
+/**
+ * @param {Buffer} buffer
+ * @param {Buffer} marker
+ * @returns {boolean}
+ */
+function startsWith(buffer, marker) {
+  if (buffer.length < marker.length) return false;
+  return buffer.subarray(0, marker.length).equals(marker);
+}
+
+/**
+ * Image branch: strip the marker header only. No XOR is ever applied here.
+ *
+ * @param {Buffer} buffer
+ * @returns {{ data: Buffer, scheme: 'plain'|'ADW'|'Gj' }}
+ */
+function deobfuscateImage(buffer) {
+  if (startsWith(buffer, MARKER_A)) {
+    return { data: buffer.subarray(MARKER_A.length), scheme: 'ADW' };
+  }
+  if (startsWith(buffer, MARKER_B)) {
+    return { data: buffer.subarray(MARKER_B.length + MARKER_B_IMAGE_PAD), scheme: 'Gj' };
+  }
+  return { data: buffer, scheme: 'plain' };
+}
+
+/**
+ * Binary branch: strip the marker header, then XOR the remaining bytes.
+ * MARKER_A uses a constant XOR of 1. MARKER_B uses a 16-byte rotating key.
+ *
+ * @param {Buffer} buffer
+ * @returns {{ data: Buffer, scheme: 'plain'|'ADW'|'Gj' }}
+ */
+function deobfuscateBinary(buffer) {
+  if (startsWith(buffer, MARKER_A)) {
+    const d = Buffer.from(buffer.subarray(MARKER_A.length));
+    for (let i = 0; i < d.length; i += 1) {
+      d[i] ^= 1;
+    }
+    return { data: d, scheme: 'ADW' };
+  }
+  if (startsWith(buffer, MARKER_B)) {
+    const d = Buffer.from(buffer.subarray(MARKER_B.length));
+    let c = 0;
+    for (let i = 0; i < d.length; i += 1) {
+      if (c >= XOR_KEY.length) c = 0;
+      d[i] ^= XOR_KEY[c];
+      c += 1;
+    }
+    return { data: d, scheme: 'Gj' };
+  }
+  return { data: buffer, scheme: 'plain' };
+}
+
+/**
+ * De-obfuscate a native asset buffer, routing to the image or binary branch
+ * based on file extension. Files without a recognised marker are returned
+ * byte-identical (scheme: 'plain').
+ *
+ * @param {Buffer} buffer  Raw bytes as received from the server.
+ * @param {string} ext     File extension, including the leading dot (e.g. '.png').
+ * @returns {{ data: Buffer, scheme: 'plain'|'ADW'|'Gj' }}
+ */
+function deobfuscateAsset(buffer, ext) {
+  const normalizedExt = (ext || '').toLowerCase();
+  if (IMAGE_EXTS.has(normalizedExt)) {
+    return deobfuscateImage(buffer);
+  }
+  return deobfuscateBinary(buffer);
+}
+
+module.exports = {
+  deobfuscateAsset,
+  MARKER_A,
+  MARKER_B,
+  MARKER_B_IMAGE_PAD,
+  XOR_KEY,
+  IMAGE_EXTS,
+};


### PR DESCRIPTION

### Problem

Cocos Creator 2.4 builds served by the Fire Kirin platform prepend an obfuscation
header to native binary assets. cc-reverse copies those bytes verbatim, so recovered
PNG/JPEG/MP3 files are unusable — `file(1)` reports `data`, and neither an image
decoder nor Cocos Creator will open them.

The prefix is present in the bytes the server delivers; it is not introduced by
cc-reverse. cc-reverse simply has no notion of it.

Observed on a real capture: **57 of 59 images and 129 of 129 audio files** were
unreadable after recovery.

### Algorithm

Taken from the game's own loader (`CommLoading/downLoadPlugin.js`), not reverse-guessed.
Two markers, two code paths:

```
MARKER_A = "@@@ADW@@@%%"           (11 bytes)
MARKER_B = "Gj&e5/S%*z]~)i!O`r"    (18 bytes)
XOR_KEY  = [75,108,38,101,5,47,82,35,41,93,126,43,105,79,96,118]
```

| Marker | Loader path | Transform |
|---|---|---|
| A | blob (image) | strip 11 |
| B | blob (image) | strip 18 **+ 74** |
| A | arraybuffer (audio/binary) | strip 11, then XOR every byte with `1` |
| B | arraybuffer (audio/binary) | strip 18, then XOR with the 16-byte rotating key |

The `+74` pad on the image path is empirically derived — it is what the loader does,
and it holds across all 167 marker-B images in the sample, but I do not know *why* it
is 74. Flagging that honestly rather than implying it is understood.

Unmarked input is returned **byte-identical**, so non-obfuscated projects are unaffected.

### Scope of this PR

This PR adds the decoder module and its tests **only**. The module is inert: it
exports a pure byte transform and is not wired into any pipeline here. Nothing in
cc-reverse's behaviour changes until a caller invokes it deliberately.

The obfuscation is **Fire Kirin-specific**, not a general Cocos feature. Integration
into the recovery pipeline is deliberately kept out of this PR; in my downstream branch
it sits behind an explicit `--deobfuscate fire-kirin` flag, with detection reported but
never silently applied. Happy to follow up with that wiring if you want it in-tree.

### Verification

- **238/238** images and **129/129** audio in a real capture decode to valid magic bytes.
- Round-trip tests build a real minimal PNG in-code (zlib deflate + hand-rolled CRC32),
  obfuscate it under each scheme, decode it back, and assert byte-exact equality plus
  independent re-parse via `image-size`. So the image branches are proven to produce a
  *decodable artifact*, not merely correct prefix arithmetic.
- The rotating-key fixture exceeds 16 bytes so key wraparound is exercised.
- Full suite green.

### Notes for review

- Zero new dependencies (`zlib` is a Node built-in; `image-size` was already a dep).
- All fixtures are **synthetic** — no game assets are vendored into the repo.
- `deobfuscateAsset(buffer, ext)` returns `{ data, scheme }` so callers can report
  what happened rather than guess.
- Files kept under the project's 200-line convention.

